### PR TITLE
Update context.cpp

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -683,7 +683,7 @@ Source *ALContext::createSource()
     ALSource *source;
     if(!mFreeSources.empty())
     {
-        source = mFreeSources.back();
+        source = mFreeSources.front();
         mFreeSources.pop();
     }
     else


### PR DESCRIPTION
_mFreeSources_ is a _queue_, which means _pop_ removes the **first** element from it.
However, it retrieves the **last** element from the queue before popping it. That means _source_ now points to an object still in the queue, and the element which was popped is now dangling.