### PR TITLE
Fix crash when a pending buffer is assigned to a source

### DIFF
--- a/src/context.cpp
+++ b/src/context.cpp
@@ -1422,12 +1422,9 @@ void ContextImpl::addPendingSource(SourceImpl *source, SharedFuture<Buffer> futu
         [](const PendingSource &lhs, SourceImpl *rhs) -> bool
         { return lhs.mSource < rhs; }
     );
-    if(iter != mPendingSources.end())
-    {
-        if(iter->mSource == source) iter->mFuture = std::move(future);
-        else mPendingSources.insert(iter, {source, std::move(future)});
-    }
-    else if(iter->mSource != source)
+    if(iter != mPendingSources.end() && iter->mSource == source)
+        iter->mFuture = std::move(future);
+    else
         mPendingSources.insert(iter, {source, std::move(future)});
 }
 


### PR DESCRIPTION
I've tried using the asynchronous buffer loading feature, and ran into a couple of bugs.

One is a dereference of an end iterator (one past last item) in `ContextImpl::addPendingSource`.
