### PR TITLE
Crash in background thread

### DIFF
--- a/src/context.h
+++ b/src/context.h
@@ -155,7 +155,7 @@ private:
         ALuint mFrames{0};
         Promise<Buffer> mPromise;
 
-        std::atomic<PendingPromise*> mNext;
+        std::atomic<PendingPromise*> mNext{nullptr};
 
         PendingPromise() = default;
         PendingPromise(BufferImpl *buffer, SharedPtr<Decoder> decoder, ALenum format,


### PR DESCRIPTION
I ran into another crash when using loading buffers asynchronously. It happens when the last queued buffer finishes loading.

The cause turned out to be an uninitialized value.