### PR TITLE
Set AL_SAMPLE_OFFSET only on sources with buffers attached.

### DIFF
--- a/src/source.h
+++ b/src/source.h
@@ -89,7 +89,7 @@ class SourceImpl {
     ALuint mPriority;
 
     void resetProperties();
-    void applyProperties(bool looping, ALuint offset) const;
+    void applyProperties(bool looping) const;
 
     ALint refillBufferStream();
 


### PR DESCRIPTION
Workaround drivers quirks, such as Creative's for X-Fis.

I believe I tackled all AL_SAMPLE_OFFSET uses. Fell free to modify the commit as you wish.