### PR TITLE
Update build instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,12 +32,11 @@ install:
         libdumb1-dev
     fi
 script:
-  - >
+  - cd build
+  - cmake ..
+  - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      cmake .
+      cmake --build . --parallel `nproc`
+    elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+      cmake --build .
     fi
-  - >
-    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      cmake .
-    fi
-  - make -j2

--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
 Alure
 =====
+[![AppVeyor][AppVeyor Badge]][AppVeyor URL]
+[![Travis][Travis Badge]][Travis URL]
 
-[![Build Status](https://api.travis-ci.org/kcat/alure.svg)](https://travis-ci.org/kcat/alure)
+[AppVeyor Badge]: https://ci.appveyor.com/api/projects/status/github/kcat/alure?branch=master&svg=true
+[AppVeyor URL]: https://ci.appveyor.com/project/ChrisRobinson/alure/branch/master
+[Travis Badge]: https://api.travis-ci.org/kcat/alure.svg
+[Travis URL]: https://travis-ci.org/kcat/alure
 
 Alure is a C++ 3D audio API. It uses OpenAL for audio rendering, and provides
 common higher-level features such as file loading and decoding, buffer caching,
@@ -10,7 +15,6 @@ source handles.
 
 Features
 --------
-
 Alure supports 3D sound rendering based on standard OpenAL features. Extra 3D
 sound features may be available depending on the extensions supported by OpenAL
 (newer versions of OpenAL Soft provide the necessary extensions and is thus
@@ -31,35 +35,33 @@ support basic PCM formats, as well as built-in decoders for FLAC (dr_flac) and
 MP3 (minimp3). Application-defined decoders are also supported in case the
 default set are insufficient.
 
-And much more...
+And much more…
 
 Building
 --------
-
-#### - Dependencies -
+### Dependencies
 Before even building, Alure requires the OpenAL development files installed,
 for example, through Creative's OpenAL SDK (available from openal.org) or from
 OpenAL Soft. Additionally you will need a C++11 or above compliant compiler to
 be able to build Alure.
 
 These following dependencies are only needed to *automatically* support the
-formats they handle;
+formats they handle:
 
-* [ogg](https://xiph.org/ogg/) : ogg playback
-* [vorbis](https://xiph.org/vorbis/) : ogg vorbis playback
-* [opusfile](http://opus-codec.org/) : opus playback
-* [SndFile](http://www.mega-nerd.com/libsndfile/) : various multi-format playback
+* [ogg](https://xiph.org/ogg/): ogg playback
+* [vorbis](https://xiph.org/vorbis/): ogg vorbis playback
+* [opusfile](http://opus-codec.org/): opus playback
+* [SndFile](http://www.mega-nerd.com/libsndfile/): various multi-format playback
 
 Two of the packaged examples require the following dependencies to be built.
 
-* [PhysFS](https://icculus.org/physfs/) : alure-physfs
-* [dumb](https://github.com/kode54/dumb) : alure-dumb
+* [PhysFS](https://icculus.org/physfs/): alure-physfs
+* [dumb](https://github.com/kode54/dumb): alure-dumb
 
 If any dependency isn't found at build time the relevant decoders or examples
 will be disabled and skipped during build.
 
-#### - Windows -
-
+### On Windows
 If your are using [MinGW-w64](https://mingw-w64.org/doku.php), the easiest way
 to get all of the dependencies above is to use [MSYS2](http://www.msys2.org/),
 which has up-to-date binaries for all of the optional and required dependencies
@@ -77,8 +79,9 @@ cmake file for Alure requires you to use the direct directory where OpenAL Soft
 headers are located (so instead of `msys/mingw64/include`, it's
 `msys/mingw64/include/AL`).
 
-After cmake generation you should have something that looks like the following
-output if you have every single dependency:
+Inside the `build` directory, run `cmake ..`. After CMake generation
+you should have something that looks like the following output
+if you have every single dependency:
 
     -- Found OpenAL: C:/msys64/mingw64/lib/libopenal.dll.a
     -- Performing Test HAVE_STD_CXX11
@@ -97,33 +100,24 @@ output if you have every single dependency:
     -- Generating done
     -- Build files have been written to: .../alure/cmake-build-debug
 
+Now you may compile the library and examples by running `cmake --build .`.
+Use `cmake --install .`, which probably requires administrative privilege,
+to install Alure library in `C:\Program Files (x86)` for it to be available
+on your system.
 
-Use `make install` to install Alure library in `C:\Program Files (x86)` for it
-to be available on your system. Otherwise simply run `make` to build the
-library and each example you have the dependencies for. Note if you use mingw
-(or mingw-w64, the name is the same for both) you may need to use
-`mingw32-make.exe` instead of `make`, and make sure that file is located in
-your path.  Note you may need to run `make install` as admin.
+### On GNU/Linux
+On Debian-based systems, the library's dependencies can be installed using
 
-#### - Linux -
+    apt install libopenal-dev libvorbis-dev libopusfile-dev libsndfile1-dev
 
-If you are using Ubuntu, many of the pre-requisites may be installed, however
-you may find that many of the header files are not.  Here is the full list of
-packages that must be installed. The list is in the format:
+Optional dependencies for examples might be install via
 
->[dependency name]: [library package name], [header package name]
+    apt install libphysfs-dev libdumb1-dev
 
-* openal-soft : libopenal1, libopenal-dev
-* ogg : libogg0, libogg-dev
-* vorbis : libvorbis0a, libvorbis-dev
-* opusfile : libopusfule0, libopusfile-dev
-* SndFile : libsndfile1, libsndfile1-dev
-* physfs : libphysfs1, libphysfs1-dev
-* dumb : libdumb1, libdumb1-dev
+On other distributions, the packages names can be adapted similarly.
 
-For each package pair, run `sudo apt-get install [packagename]`. After doing so
-you should get a cmake output that looks something like:
-
+Then inside `build`, running `cmake ..` may gives you something similar to
+the following
 
     -- Found OpenAL: /usr/lib/x86_64-linux-gnu/libopenal.so
     -- Performing Test HAVE_STD_CXX11
@@ -146,11 +140,9 @@ you should get a cmake output that looks something like:
     -- Generating done
     -- Build files have been written to: .../alure/cmake-build-debug
 
-Use `sudo make install` to install Alure library on your system. Otherwise
-simply run `make` to build the library and each example you have the
-dependencies for.
+To build the library and each example you have the dependencies for,
+run `cmake --build . --parallel $(nproc)`.  Use `sudo cmake --install .`
+to install Alure library on your system.
 
-#### - OSX - 
-
+### On macOS
 TODO
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,16 +11,12 @@ install:
     # Remove the VS Xamarin targets to reduce AppVeyor specific noise in build
     # logs. See: http://help.appveyor.com/discussions/problems/4569
     - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
-    - curl "https://openal-soft.org/openal-binaries/openal-soft-1.19.1-bin.zip" -o openal-soft-1.19.1-bin.zip
-    - 7z x -o%APPVEYOR_BUILD_FOLDER%\.. openal-soft-1.19.1-bin.zip
-    - set OPENALDIR=%APPVEYOR_BUILD_FOLDER%\..\openal-soft-1.19.1-bin
+    - curl "https://openal-soft.org/openal-binaries/openal-soft-1.20.1-bin.zip" -o openal-soft-1.20.1-bin.zip
+    - 7z x -o%APPVEYOR_BUILD_FOLDER%\.. openal-soft-1.20.1-bin.zip
+    - set OPENALDIR=%APPVEYOR_BUILD_FOLDER%\..\openal-soft-1.20.1-bin
 
 build_script:
-- cmd: >-
-    mkdir build
-
+- cmd: |
     cd build
-
     cmake -G"%GEN%" ..
-
     cmake --build . --config %CFG% --clean-first


### PR DESCRIPTION
The change in README includes:
* Use generator-independent commands for build and install
* Build in a separate directory to avoid contaminating the source tree
* Force parallel compilation on GNU/Linux
* Clean up dependencies installation guide on GNU/Linux
* Mention the package on NixOS

Additionally, I've edited the test build in the CIs accordingly.