### PR TITLE
Add complete build instruction for macOS to README and Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,42 +1,43 @@
 language: cpp
-matrix:
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.9
+      - libopenal-dev
+      - libvorbis-dev
+      - libopusfile-dev
+      - libsndfile1-dev
+      - libphysfs-dev
+      - libdumb1-dev
+  homebrew:
+    packages:
+      - openal-soft
+      - libvorbis
+      - opusfile
+      - libsndfile
+      - physfs
+      - dumb
+    update: true
+
+git:
+  depth: 1
+
+jobs:
   include:
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - g++-4.9
-      env:
-         - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
     - os: osx
-      osx_image: xcode8
-sudo: required
-before_install:
-  - >
-    if [[ x"${MATRIX_EVAL}" != x"" ]]; then
-      eval "${MATRIX_EVAL}"
-    fi
-install:
-  - >
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      # Install OpenAL, VorbisFile, OpusFile, libsndfile, PhysicsFS,
-      # and DUMB dependencies for decoders and examples.
-      sudo apt-get install -qq \
-        libopenal-dev \
-        libvorbis-dev \
-        libopusfile-dev \
-        libsndfile1-dev \
-        libphysfs-dev \
-        libdumb1-dev
-    fi
+      script:
+        - cd build
+        - OPENALDIR=`brew --prefix openal-soft` cmake -DCMAKE_FIND_FRAMEWORK=NEVER ..
+        - cmake --build . --parallel `sysctl -n hw.ncpu`
+    - os: osx
+      env: NPROC=`sysctl -n hw.ncpu`
+    - os: linux
+      env: CC=gcc-4.9 CXX=g++-4.9 NPROC=`nproc`
+
 script:
   - cd build
   - cmake ..
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      cmake --build . --parallel `nproc`
-    elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      cmake --build .
-    fi
+  - cmake --build . --parallel $NPROC

--- a/README.md
+++ b/README.md
@@ -84,10 +84,7 @@ you should have something that looks like the following output
 if you have every single dependency:
 
     -- Found OpenAL: C:/msys64/mingw64/lib/libopenal.dll.a
-    -- Performing Test HAVE_WALL_SWITCH
-    -- Performing Test HAVE_WALL_SWITCH - Success
-    -- Performing Test HAVE_WEXTRA_SWITCH
-    -- Performing Test HAVE_WEXTRA_SWITCH - Success
+    -- Found Threads: TRUE
     -- Found OGG: C:/msys64/mingw64/lib/libogg.dll.a
     -- Found VORBIS: C:/msys64/mingw64/lib/libvorbisfile.dll.a
     -- Found OPUS: C:/msys64/mingw64/lib/libopusfile.dll.a
@@ -96,7 +93,7 @@ if you have every single dependency:
     -- Found DUMB: C:/msys64/mingw64/lib/libdumb.dll.a
     -- Configuring done
     -- Generating done
-    -- Build files have been written to: .../alure/cmake-build-debug
+    -- Build files have been written to: .../alure/build
 
 Now you may compile the library and examples by running `cmake --build .`.
 Use `cmake --install .`, which probably requires administrative privilege,
@@ -114,18 +111,11 @@ Optional dependencies for examples might be install via
 
 On other distributions, the packages names can be adapted similarly.
 
-Then inside `build`, running `cmake ..` may gives you something similar to
+Then inside `build`, the output of `cmake ..` should contains lines similar to
 the following
 
     -- Found OpenAL: /usr/lib/x86_64-linux-gnu/libopenal.so
-    -- Performing Test HAVE_WALL_SWITCH
-    -- Performing Test HAVE_WALL_SWITCH - Success
-    -- Performing Test HAVE_WEXTRA_SWITCH
-    -- Performing Test HAVE_WEXTRA_SWITCH - Success
-    -- Performing Test HAVE_GCC_DEFAULT_VISIBILITY
-    -- Performing Test HAVE_GCC_DEFAULT_VISIBILITY - Success
-    -- Performing Test HAVE_VISIBILITY_HIDDEN_SWITCH
-    -- Performing Test HAVE_VISIBILITY_HIDDEN_SWITCH - Success
+    -- Found Threads: TRUE
     -- Found OGG: /usr/lib/x86_64-linux-gnu/libogg.so
     -- Found VORBIS: /usr/lib/x86_64-linux-gnu/libvorbisfile.so
     -- Found OPUS: /usr/lib/libopusfile.so
@@ -134,11 +124,46 @@ the following
     -- Found DUMB: /usr/lib/x86_64-linux-gnu/libdumb.so
     -- Configuring done
     -- Generating done
-    -- Build files have been written to: .../alure/cmake-build-debug
+    -- Build files have been written to: .../alure/build
 
 To build the library and each example you have the dependencies for,
 run `cmake --build . --parallel $(nproc)`.  Use `sudo cmake --install .`
 to install Alure library on your system.
 
 ### On macOS
-TODO
+OpenAL is provided by Apple via [Core Audio], while optional codecs and
+examples' dependencies are available on [Homebrew](https://brew.sh/):
+
+    brew install libvorbis opusfile libsndfile
+    brew install phyfs dumb
+
+Then inside `build`, the output of `cmake ..` should contains lines similar to
+the following
+
+    -- Found OpenAL: /System/Library/Frameworks/OpenAL.framework
+    -- Found Threads: TRUE
+    -- Found OGG: /usr/local/lib/libogg.dylib
+    -- Found VORBIS: /usr/local/lib/libvorbisfile.dylib
+    -- Found OPUS: /usr/local/lib/libopusfile.dylib
+    -- Found SndFile: /usr/local/lib/libsndfile.dylib
+    -- Found PhysFS: /usr/local/lib/libphysfs.dylib
+    -- Found DUMB: /usr/local/lib/libdumb.a
+    -- Configuring done
+    -- Generating done
+    -- Build files have been written to: .../alure/build
+
+If OpenAL Soft is preferred, one may install it from Homebrew and specify
+CMake prefix path accordingly
+
+    brew install openal-soft
+    OPENALDIR=`brew --prefix openal-soft` cmake -DCMAKE_FIND_FRAMEWORK=NEVER ..
+
+and get
+
+    -- Found OpenAL: /usr/local/opt/openal-soft/lib/libopenal.dylib
+
+To build the library and each example you have the dependencies for,
+run `cmake --build . --parallel $(sysctl -n hw.ncpu)`.
+Use `sudo cmake --install .` to install Alure library on your system.
+
+[Core Audio]: https://developer.apple.com/library/archive/documentation/MusicAudio/Conceptual/CoreAudioOverview/WhatsinCoreAudio/WhatsinCoreAudio.html


### PR DESCRIPTION
Changes to `.travis.yml` includes:
* Use Travis' default version of macOS: [I had trouble getting Homebrew working on xcode8](https://travis-ci.org/kcat/alure/jobs/647727039) (macOS 10.11); also this provide a newer version of CMake with `--parallel` for faster building.
* Use environment variable for the number of logical CPU core, thus generalize script
* Set git depth to 1
* Use addons for dependencies installation.

I am unsure how to get CMake to choose OpenAL Soft over the builtin so currently alure is build against the Core Audio version.